### PR TITLE
JJBB: exclude branches in the upstream that are for bumping

### DIFF
--- a/.ci/jobs/azure-vm-extension-mbp.yml
+++ b/.ci/jobs/azure-vm-extension-mbp.yml
@@ -13,6 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        head-filter-regex: '(master|PR-.*)'
         notification-context: 'beats-ci'
         repo: azure-vm-extension
         repo-owner: elastic


### PR DESCRIPTION
Since there is a new automation in place to bump the Elastic Stack versions, then let's filter those branches that are not needed