### PR TITLE
CI, somehow post-failure runs on success stages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -78,22 +78,12 @@ pipeline {
                 }
               }
             }
-            post {
-              failure {
-                destroyCluster()
-              }
-            }
           }
           stage('Prepare tools') {
             options { skipDefaultCheckout() }
             steps {
               withCloudEnv() {
                 sh(label: 'Prepare tools', script: 'make -C .ci prepare')
-              }
-            }
-            post {
-              failure {
-                destroyCluster()
               }
             }
           }
@@ -106,12 +96,6 @@ pipeline {
                     sh(label: 'Run terraform plan', script: 'make -C .ci terraform-run')
                   }
                 }
-              }
-            }
-            post {
-              failure {
-                destroyTerraform()
-                destroyCluster()
               }
             }
           }
@@ -127,9 +111,13 @@ pipeline {
             post {
               always {
                 destroyTerraform()
-                destroyCluster()
               }
             }
+          }
+        }
+        post {
+          always {
+            destroyCluster()
           }
         }
       }

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -87,22 +87,12 @@ pipeline {
                 }
               }
             }
-            post {
-              failure {
-                destroyCluster()
-              }
-            }
           }
           stage('Prepare tools') {
             options { skipDefaultCheckout() }
             steps {
               withCloudEnv() {
                 sh(label: 'Prepare tools', script: 'make -C .ci prepare')
-              }
-            }
-            post {
-              failure {
-                destroyCluster()
               }
             }
           }
@@ -115,12 +105,6 @@ pipeline {
                     sh(label: 'Run terraform plan', script: 'make -C .ci terraform-run')
                   }
                 }
-              }
-            }
-            post {
-              failure {
-                destroyTerraform()
-                destroyCluster()
               }
             }
           }
@@ -136,9 +120,13 @@ pipeline {
             post {
               always {
                 destroyTerraform()
-                destroyCluster()
               }
             }
+          }
+        }
+        post {
+          always {
+            destroyCluster()
           }
         }
       }


### PR DESCRIPTION
### What

Refactor the post-failure post in the stages to run in the meta-stage

### Why

Sometimes the post-failure in the stage runs even though there was no failure related, see:

![image](https://user-images.githubusercontent.com/2871786/122555996-e5f65380-d032-11eb-96ae-57dcce5d1d64.png)

`prepare tools` stage passed as you can see in the `make -C .ci prepare` step, but the `destroy cluster` was executed. And the `Terraform` stage failed since the cluster was destroyed....

I guess, this is somehow related to some race condition and status from some other stages in another axis.



