### PR TITLE
Slack message with the stage failures

### DIFF
--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -192,7 +192,7 @@ def slackStageStatus() {
   if (failedStages.isEmpty()) {
     return "*ITs*: ${env.REPO}"
   } else {
-    def message = "*ITs failed*:"
+    def message = "*ITs failed*: "
     failedStages.each { k, v ->
       def data = k?.split('\\|')
       message += "\n- Stage: ${data[0]} (${data[1]} - ${data[2]})"

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -156,7 +156,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true, slackHeader: "${slackStageStatus()}", slackChannel: "${env.SLACK_CHANNEL}", slackComment: true, slackNotify: (isBranch() || isTag()))
+      notifyBuildResult(prComment: true, slackHeader: "${slackStageStatus()}", slackChannel: "${env.SLACK_CHANNEL}", slackComment: true, slackNotify: (isPR() || isBranch() || isTag()))
     }
   }
 }

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -178,7 +178,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true, slackHeader: "${slackStageStatus()}", slackChannel: "${env.SLACK_CHANNEL}", slackComment: true, slackNotify: (isPR() || isBranch() || isTag()))
+      notifyBuildResult(prComment: true, slackHeader: "${slackStageStatus()}", slackChannel: "${env.SLACK_CHANNEL}", slackComment: true, slackNotify: true)
     }
   }
 }

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -166,7 +166,7 @@ def failedStage(String name) {
 }
 
 def slackStageStatus() {
-  def message = "*ITs*: ${env.REPO}"
+  echo "slackStageStatus: started"
   if (failedStages.isEmpty()) {
     return "*ITs*: ${env.REPO}"
   } else {

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -194,7 +194,7 @@ def slackStageStatus() {
   } else {
     def message = "*ITs failed*:"
     failedStages.each { k, v ->
-      def data = k?.split('|')
+      def data = k?.split('\\|')
       message += "\n- Stage: ${data[0]} (${data[1]} - ${data[2]})"
     }
     echo "slackStageStatus: ${message}"

--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -167,14 +167,15 @@ def failedStage(String name) {
 
 def slackStageStatus() {
   def message = "*ITs*: ${env.REPO}"
-  if (stageStatus.isEmpty()) {
+  if (failedStages.isEmpty()) {
     return "*ITs*: ${env.REPO}"
   } else {
     def message = "*ITs failed*:"
-    stageStatus.each { k, v ->
+    failedStages.each { k, v ->
       def data = k?.split('|')
       message += "\n- Stage: ${data[0]} (${data[1]} - ${data[2]})"
     }
+    echo "slackStageStatus: ${message}"
     return message
   }
 }


### PR DESCRIPTION
### What

Add the stages that failed when running the nightly ITs in the slack message.


### Tests


For instance, given a build that failed in the CI the slack message looks like


![image](https://user-images.githubusercontent.com/2871786/123977116-9f9bdf80-d9b6-11eb-918c-5fd9b0af9e6a.png)


Pipeline view

![image](https://user-images.githubusercontent.com/2871786/123977217-b6423680-d9b6-11eb-8590-9745d6a16ff4.png)

