### PR TITLE
CI: workaround the CI matrix issue with post-stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -23,6 +23,10 @@ import groovy.transform.Field
 // key is the cluster name and value is the VM name
 @Field def vms = [:]
 
+// Passed stages to workaround the matrix/post-build
+// See https://issues.jenkins.io/browse/JENKINS-65997
+@Field def successStages = [:]
+
 pipeline {
   agent none
   environment {
@@ -71,34 +75,49 @@ pipeline {
           }
           stage('Create cluster'){
             options { skipDefaultCheckout() }
+            environment {
+              STAGE_NAME = "Create cluster|${STACK_VERSION}|${OS_VERSION}"
+            }
             steps {
               withGithubNotify(context: "Create Cluster ${ELASTIC_STACK_VERSION} ${OS_VERSION}") {
                 withVaultEnv(){
                   sh(label: 'Deploy Cluster', script: 'make -C .ci create-cluster')
                 }
               }
+              successStage(env.STAGE_NAME)
             }
             post {
               failure {
-                destroyCluster()
+                whenFalse(isSuccessStage(env.STAGE_NAME)) {
+                  destroyCluster()
+                }
               }
             }
           }
           stage('Prepare tools') {
             options { skipDefaultCheckout() }
+            environment {
+              STAGE_NAME = "Tools|${STACK_VERSION}|${OS_VERSION}"
+            }
             steps {
               withCloudEnv() {
                 sh(label: 'Prepare tools', script: 'make -C .ci prepare')
               }
+              successStage(env.STAGE_NAME)
             }
             post {
               failure {
-                destroyCluster()
+                whenFalse(isSuccessStage(env.STAGE_NAME)) {
+                  destroyCluster()
+                }
               }
             }
           }
           stage('Terraform') {
             options { skipDefaultCheckout() }
+            environment {
+              STAGE_NAME = "Terraform|${STACK_VERSION}|${OS_VERSION}"
+            }
             steps {
               withGithubNotify(context: "Terraform ${ELASTIC_STACK_VERSION} ${OS_VERSION}") {
                 withCloudEnv() {
@@ -107,11 +126,14 @@ pipeline {
                   }
                 }
               }
+              successStage(env.STAGE_NAME)
             }
             post {
               failure {
-                destroyTerraform()
-                destroyCluster()
+                whenFalse(isSuccessStage(env.STAGE_NAME)) {
+                  destroyTerraform()
+                  destroyCluster()
+                }
               }
             }
           }
@@ -141,6 +163,14 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
   }
+}
+
+def successStage(String name) {
+  successStages[name] = true
+}
+
+def isSuccessStage(String name) {
+  return successStages.containsKey(name)
 }
 
 def destroyCluster( ) {


### PR DESCRIPTION
### What

Fixes  https://issues.jenkins.io/browse/JENKINS-65997.

Store the stage status in the matrix and run the post-failure if there was a failure in that particular stage, rather than globally since `failFast: false`

### Why

There is a corner case with a `failFast: false` in a matrix section that if one of the axis stages failed then the success ones execute the `post-failure` step when it should not.

### Issue

See https://github.com/elastic/azure-vm-extension/pull/22