### PR TITLE
ATs: Fix 503 errors

### DIFF
--- a/test/ats/validate.py
+++ b/test/ats/validate.py
@@ -51,7 +51,8 @@ class TestIndices(unittest.TestCase):
                                     ]
                                 }
                             }
-                        }
+                        },
+                        ignore=503
                     )
             count = records_count['count']
             if count >= compare_with:
@@ -72,7 +73,7 @@ class TestIndices(unittest.TestCase):
             if tries > total:
                 break
             print("count: {} out of {}".format(tries, total))
-            records_count = self.es.count(index=index_name, body={"query": {"match": {"agent.hostname": hostname}}})
+            records_count = self.es.count(index=index_name, body={"query": {"match": {"agent.hostname": hostname}}}, ignore=503)
             count = records_count['count']
             if count >= compare_with:
                 break
@@ -95,7 +96,7 @@ class TestIndices(unittest.TestCase):
             print("exists: {} out of {}".format(tries, total))
             ## Deprecated to access system indices
             ## https://github.com/elastic/elasticsearch/issues/50251
-            exist = self.es.indices.exists(index_name)
+            exist = self.es.indices.exists(index_name, ignore=503)
             if exist:
                 break
             tries += 1


### PR DESCRIPTION
Fixes some 503 http errors
```
[2021-08-02T14:12:25.774Z] ======================================================================
[2021-08-02T14:12:25.774Z] ERROR [45.729s]: test_indice_ds_logs_linux_diskio (validate.TestIndices)
[2021-08-02T14:12:25.774Z] ----------------------------------------------------------------------
[2021-08-02T14:12:25.774Z] Traceback (most recent call last):
[2021-08-02T14:12:25.774Z]   File "/app/test/ats/validate.py", line 140, in test_indice_ds_logs_linux_diskio
[2021-08-02T14:12:25.774Z]     self.count_and_test('.ds-logs-system.syslog-default-*', self.hostname, 1)
[2021-08-02T14:12:25.774Z]   File "/app/test/ats/validate.py", line 107, in count_and_test
[2021-08-02T14:12:25.774Z]     records_count = self.count(index_name, hostname, compare_with)
[2021-08-02T14:12:25.774Z]   File "/app/test/ats/validate.py", line 75, in count
[2021-08-02T14:12:25.774Z]     records_count = self.es.count(index=index_name, body={"query": {"match": {"agent.hostname": hostname}}})
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/client/utils.py", line 168, in _wrapped
[2021-08-02T14:12:25.774Z]     return func(*args, params=params, headers=headers, **kwargs)
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/client/__init__.py", line 549, in count
[2021-08-02T14:12:25.774Z]     return self.transport.perform_request(
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/transport.py", line 413, in perform_request
[2021-08-02T14:12:25.774Z]     raise e
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/transport.py", line 381, in perform_request
[2021-08-02T14:12:25.774Z]     status, headers_response, data = connection.perform_request(
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/connection/http_urllib3.py", line 277, in perform_request
[2021-08-02T14:12:25.774Z]     self._raise_error(response.status, raw_data)
[2021-08-02T14:12:25.774Z]   File "/usr/local/lib/python3.9/site-packages/********search/connection/base.py", line 330, in _raise_error
[2021-08-02T14:12:25.774Z]     raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
[2021-08-02T14:12:25.774Z] ********search.exceptions.TransportError: TransportError(503, 'search_phase_execution_exception', None)
[2021-08-02T14:12:25.774Z] 
[2021-08-02T14:12:25.774Z] ----------------------------------------------------------------------
[2021-08-02T14:12:25.774Z] Ran 8 tests in 46.337s
```