### PR TITLE
503 returns a different output

### DIFF
--- a/test/ats/validate.py
+++ b/test/ats/validate.py
@@ -54,9 +54,10 @@ class TestIndices(unittest.TestCase):
                         },
                         ignore=503
                     )
-            count = records_count['count']
-            if count >= compare_with:
-                break
+            if "count" in records_count:
+                count = records_count['count']
+                if count >= compare_with:
+                    break
             tries += 1
             time.sleep(5)
             continue
@@ -74,9 +75,10 @@ class TestIndices(unittest.TestCase):
                 break
             print("count: {} out of {}".format(tries, total))
             records_count = self.es.count(index=index_name, body={"query": {"match": {"agent.hostname": hostname}}}, ignore=503)
-            count = records_count['count']
-            if count >= compare_with:
-                break
+            if "count" in records_count:
+                count = records_count['count']
+                if count >= compare_with:
+                    break
             tries += 1
             time.sleep(5)
             continue


### PR DESCRIPTION
Fixes

```
[2021-08-04T08:08:59.943Z] ======================================================================
[2021-08-04T08:08:59.943Z] ERROR [5.199s]: test_indice_ds_metrics_cpu (validate.TestIndices)
[2021-08-04T08:08:59.943Z] ----------------------------------------------------------------------
[2021-08-04T08:08:59.943Z] Traceback (most recent call last):
[2021-08-04T08:08:59.943Z]   File "/app/test/ats/validate.py", line 130, in test_indice_ds_metrics_cpu
[2021-08-04T08:08:59.943Z]     self.count_and_test('.ds-metrics-system.cpu-default-*', self.hostname, 1)
[2021-08-04T08:08:59.943Z]   File "/app/test/ats/validate.py", line 108, in count_and_test
[2021-08-04T08:08:59.943Z]     records_count = self.count(index_name, hostname, compare_with)
[2021-08-04T08:08:59.943Z]   File "/app/test/ats/validate.py", line 77, in count
[2021-08-04T08:08:59.943Z]     count = records_count['count']
[2021-08-04T08:08:59.943Z] KeyError: 'count'

```