### PR TITLE
[CI] enable triggers section with obltGitHubComments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,6 +46,9 @@ pipeline {
     timeout(time: 2, unit: 'HOURS')
     disableConcurrentBuilds()
   }
+  triggers {
+    issueCommentTrigger("${obltGitHubComments()}")
+  }
   parameters {
     booleanParam(name: 'skipDestroy', defaultValue: "false", description: "Whether to skip the destroy of the cluster and terraform.")
   }


### PR DESCRIPTION
## What does this PR do?

Enable triggers section with the  https://github.com/elastic/apm-pipeline-library/blob/master/vars/obltGitHubComments.txt

## Why is it important?

Avoid hardcoded strings and easy to normalise the GitHub comments in all the oblt projects

You can also see in the GitHub comment that there is a specific section for **some** of those GitHub comments called `🤖 GitHub comments`