### PR TITLE
[deployment] use elastic_cloud_tf_azure.yml

### DIFF
--- a/test/deployment/elastic_cloud.yml
+++ b/test/deployment/elastic_cloud.yml
@@ -7,17 +7,17 @@ grab_cluster_info: false
 certificate_issuer: letsencrypt-staging
 
 elastic_cloud:
-  provider: aws
-  region: us-east-1
-  host: staging.foundit.no
-  nodes_per_zone: 1
+  provider: azure
+  region: azure-eastus2
+  endpoint: https://staging.found.no
   zones: 1
+  template: azure-observability-v2
 
 k8s:
   enabled: false
   provider: none
   project: "elastic-observability"
-  region: "europe-west1-c"
+  region: us-central1-c
   max_node_count: "3"
   machine_type: "n1-standard-4"
   default_namespace: "default"
@@ -26,18 +26,18 @@ k8s:
 elasticsearch:
   enabled: true
   version: "{{ stack_version }}"
-  type: ec
+  type: tf
   mem: 2
 
 kibana:
   enabled: true
   version: "{{ stack_version }}"
-  type: ec
+  type: tf
   mem: 2
   apm_enabled: false
 
 apm:
   enabled: true
   version: "{{ stack_version }}"
-  type: ec
+  type: tf
   mem: 0.5


### PR DESCRIPTION
### What

ECL deployment is not supported anymore


### Follow ups

Consume `tests/environments/elastic_cloud_tf_azure.yml` rather than maintaining a copy in this repository.