### PR TITLE
[automation] Update Elastic stack release version 7.17.0 7.17.1

### DIFF
--- a/.ci/its.groovy
+++ b/.ci/its.groovy
@@ -67,7 +67,7 @@ pipeline {
             // The below line is part of the bump release automation
             // if you change anything please modifies the file
             // .ci/bump-stack-release-version.sh
-            values '8.0.0-SNAPSHOT', '7.16.0', '7.15.0'
+            values '8.0.0-SNAPSHOT', '7.17.0', '7.17.1'
           }
           axis {
             name 'OS_VERSION'


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 7.17.0 7.17.1