### PR TITLE
Fix path for requirements file in docker build

### DIFF
--- a/.ci/docker/azure-vm-tools/Dockerfile
+++ b/.ci/docker/azure-vm-tools/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 ## this image is build from the .ci folder location
-COPY docker/azure-vm-tools/requirements.txt /app/
+COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT [ "/app/.ci/docker/azure-vm-tools/entrypoint.sh" ]


### PR DESCRIPTION
Quick fix for failing build:

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fdocker-images%2Fazure-vm-tools/detail/azure-vm-tools/32/pipeline
