### PR TITLE
Delete the VM extension settings after the install

### DIFF
--- a/src/handler/linux/enable.sh
+++ b/src/handler/linux/enable.sh
@@ -114,8 +114,6 @@ Install_ElasticAgent_OTHER()
     log "INFO" "[Install_ElasticAgent_OTHER] installed Elastic Agent $STACK_VERSION"
 }
 
-
-
 # Enroll_ElasticAgent enrolls the elastic agent to Fleet
 Enroll_ElasticAgent() {
   get_kibana_host
@@ -347,12 +345,10 @@ Run_Agent()
   if [ "$DISTRO_OS" = "DEB" ] || [ "$DISTRO_OS" = "RPM" ]; then
     Run_Agent_DEB_RPM
   else
-   Run_Agent_Other
+    Run_Agent_Other
   fi
+
+  clean_and_exit 0
 }
 
 Run_Agent
-
-
-
-

--- a/src/handler/linux/helper.sh
+++ b/src/handler/linux/helper.sh
@@ -55,7 +55,7 @@ get_logs_location()
    if [ -e $ES_EXT_DIR/HandlerEnvironment.json ]; then
     LOGS_FOLDER=$(jq -r '.[0].handlerEnvironment.logFolder' $ES_EXT_DIR/HandlerEnvironment.json)
   else
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -68,7 +68,7 @@ get_status_location()
 then
     STATUS_FOLDER=$(jq -r '.[0].handlerEnvironment.statusFolder' $ES_EXT_DIR/HandlerEnvironment.json)
 else
-    exit 1
+    clean_and_exit
 fi
 }
 
@@ -110,7 +110,7 @@ get_configuration_location()
     log "INFO" "[get_configuration_location] configuration file $CONFIG_FILE found"
   else
     log "ERROR" "[get_configuration_location] HandlerEnvironment.json file not found"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -123,7 +123,7 @@ get_cloud_id()
     log "INFO" "[get_cloud_id] Found cloud id $CLOUD_ID"
   else
     log "[get_cloud_id] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -136,7 +136,7 @@ get_protected_settings()
     log "INFO" "[get_protected_settings] Found protected settings"
   else
     log "[get_protected_settings] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -149,7 +149,7 @@ get_thumbprint()
     log "INFO" "[get_thumbprint] Found thumbprint $THUMBPRINT"
   else
     log "[get_thumbprint] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -162,7 +162,7 @@ get_username()
     log "INFO" "[get_username] Found username  $USERNAME"
   else
     log "ERROR" "[get_username] Configuration file not found"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -177,7 +177,7 @@ get_kibana_host () {
     log "INFO" "[get_kibana_host] Found Kibana uri $KIBANA_URL"
  else
     log "ERROR" "[get_kibana_host] Cloud ID could not be parsed"
-    exit 1
+    clean_and_exit
   fi
 
 }
@@ -193,7 +193,7 @@ get_elasticsearch_host () {
     log "INFO" "[get_elasticsearch_host] Found ES uri $ELASTICSEARCH_URL"
   else
     log "ERROR" "[get_elasticsearch_host] Cloud ID could not be parsed"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -203,20 +203,20 @@ get_cloud_stack_version () {
   get_elasticsearch_host
   if [ "$ELASTICSEARCH_URL" = "" ]; then
     log "ERROR" "[get_cloud_stack_version] Elasticsearch URL could not be found"
-    exit 1
+    clean_and_exit
   fi
   get_password
   get_base64Auth
    if [ "$PASSWORD" = "" ] && [ "$BASE64_AUTH" = "" ]; then
     log "ERROR" "[get_cloud_stack_version] Both PASSWORD and BASE64AUTH key could not be found"
-    exit 1
+    clean_and_exit
   fi
   local cred=""
   if [ "$PASSWORD" != "" ] && [ "$PASSWORD" != "null" ]; then
     get_username
     if [ "$USERNAME" = "" ]; then
       log "ERROR" "[get_cloud_stack_version] USERNAME could not be found"
-      exit 1
+      clean_and_exit
     fi
     cred=${USERNAME}:${PASSWORD}
   else
@@ -226,7 +226,7 @@ get_cloud_stack_version () {
   local EXITCODE=$?
   if [ $EXITCODE -ne 0 ]; then
       log "ERROR" "[get_cloud_stack_version] error pinging $ELASTICSEARCH_URL"
-      exit $EXITCODE
+      clean_and_exit $EXITCODE
   fi
   STACK_VERSION=$(echo $json_result | jq -r '.version.number')
   log "INFO" "[get_cloud_stack_version] Stack version found is $STACK_VERSION"
@@ -289,7 +289,8 @@ function retry_backoff() {
     fi
     if [[ $attempt -eq $attempts ]]; then
       log "ERROR" "[retry_backoff] Function failed on last attempt $attempt."
-      exit 1
+      # clean_and_exit
+      clean_and_exit
     fi
     local sleep_ms="$(($sleep_millis))"
     sleep "${sleep_ms:0:-3}.${sleep_ms: -3}"
@@ -358,8 +359,9 @@ write_status() {
       filename="$(basename -- $CONFIG_FILE)"
       sequenceNumber=$(echo $filename | cut -f1 -d.)
     else
-    log "[write_status] Configuration file not found" "ERROR"
-    exit 1
+      log "[write_status] Configuration file not found" "ERROR"
+      # clean_and_exit
+      clean_and_exit
     fi
   json="[{\"version\":\"1.0\",\"timestampUTC\":\"$timestampUTC\",\"status\":{\"name\":\"$name\",\"operation\":\"$operation\",\"status\":\"$mainStatus\",\"formattedMessage\": { \"lang\":\"en-US\", \"message\":\"$message\"},\"substatus\": [{ \"name\":\"$subName\", \"status\":\"$subStatus\",\"code\":\"$code\",\"formattedMessage\": { \"lang\":\"en-US\", \"message\":\"$subMessage\"}}]}} ]"
   echo $json > "$STATUS_FOLDER"/"$sequenceNumber".status
@@ -374,7 +376,8 @@ encrypt() {
     openssl cms -encrypt -in <(echo "$2") -inkey $private_key_path -recip $cert_path -inform dem
   else
     echo "ERROR" "[decrypt] Decryption failed. Could not find certificates"
-  exit 1
+    # clean_and_exit
+    clean_and_exit
   fi
 }
 
@@ -389,7 +392,8 @@ get_password() {
     PASSWORD=$(echo "$protected_settings" | jq -r '.password')
   else
     log "ERROR" "[get_password] Decryption failed. Could not find certificates"
-    exit 1
+    # clean_and_exit
+    clean_and_exit
   fi
 }
 
@@ -404,7 +408,8 @@ get_base64Auth() {
     BASE64_AUTH=$(echo "${protected_settings}" | jq -r '.base64Auth')
   else
     log "ERROR" "[get_base64Auth] Decryption failed. Could not find certificates"
-    exit 1
+    # clean_and_exit
+    clean_and_exit
   fi
 }
 
@@ -420,7 +425,8 @@ is_new_config(){
     newSequence=$(echo $filename | cut -f1 -d.)
   else
     log "[get_sequence] Configuration file not found" "ERROR"
-    exit 1
+    # clean_and_exit
+    clean_and_exit
   fi
   if [ "$LOGS_FOLDER" = "" ]; then
       get_logs_location
@@ -474,7 +480,7 @@ function set_sequence_to_file
     log "INFO" "[set_sequence_to_file] Sequence has been set"
   else
     log "[set_sequence_to_file] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -492,7 +498,7 @@ get_prev_configuration_location()
     log "INFO" "[get_prev_configuration_location] configuration file $OLD_CONFIG_FILE found"
   else
     log "ERROR" "[get_prev_configuration_location] HandlerEnvironment.json file not found"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -505,7 +511,7 @@ get_prev_username()
     log "INFO" "[get_prev_username] Found username  OLD_USERNAME"
   else
     log "ERROR" "[get_prev_username] Configuration file not found"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -518,7 +524,7 @@ get_prev_cloud_id()
     log "INFO" "[get_prev_cloud_id] Found cloud id $OLD_CLOUD_ID"
   else
     log "[get_prev_cloud_id] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -533,7 +539,7 @@ get_prev_kibana_host () {
     log "INFO" "[get_prev_kibana_host] Found Kibana uri $OLD_KIBANA_URL"
  else
     log "ERROR" "[get_prev_kibana_host] Cloud ID could not be parsed"
-    exit 1
+    clean_and_exit
   fi
 
 }
@@ -549,7 +555,7 @@ get_prev_elasticsearch_host () {
     log "INFO" "[get_prev_elasticsearch_host] Found ES uri $OLD_ELASTICSEARCH_URL"
   else
     log "ERROR" "[get_prev_elasticsearch_host] Cloud ID could not be parsed"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -562,7 +568,7 @@ get_prev_protected_settings()
     log "INFO" "[get_prev_protected_settings] Found protected settings $OLD_PROTECTED_SETTINGS"
   else
     log "[get_prev_protected_settings] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -575,7 +581,7 @@ get_prev_thumbprint()
     log "INFO" "[get_prev_thumbprint] Found thumbprint $OLD_THUMBPRINT"
   else
     log "[get_prev_thumbprint] Configuration file not found" "ERROR"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -591,7 +597,7 @@ get_prev_password() {
     OLD_PASSWORD=$(echo "$protected_settings" | jq -r '.password')
   else
     log "ERROR" "[get_prev_password] Decryption failed. Could not find certificates"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -606,7 +612,7 @@ get_prev_base64Auth() {
     OLD_BASE64_AUTH=$(echo "${protected_settings}" | jq -r '.base64Auth')
   else
     log "ERROR" "[get_prev_base64Auth] Decryption failed. Could not find certificates"
-    exit 1
+    clean_and_exit
   fi
 }
 
@@ -616,20 +622,20 @@ get_prev_cloud_stack_version () {
   get_prev_elasticsearch_host
   if [ "$OLD_ELASTICSEARCH_URL" = "" ]; then
     log "ERROR" "[get_prev_cloud_stack_version] Elasticsearch URL could not be found"
-    exit 1
+    clean_and_exit
   fi
   get_prev_password
   get_prev_base64Auth
    if [ "$OLD_PASSWORD" = "" ] && [ "$OLD_BASE64_AUTH" = "" ]; then
     log "ERROR" "[get_prev_cloud_stack_version] Both PASSWORD and BASE64AUTH key could not be found"
-    exit 1
+    clean_and_exit
   fi
   local cred=""
   if [ "$OLD_PASSWORD" != "" ] && [ "$OLD_PASSWORD" != "null" ]; then
     get_prev_username
     if [ "$OLD_USERNAME" = "" ]; then
       log "ERROR" "[get_prev_cloud_stack_version] USERNAME could not be found"
-      exit 1
+      clean_and_exit
     fi
     cred=${OLD_USERNAME}:${OLD_PASSWORD}
   else
@@ -639,8 +645,23 @@ get_prev_cloud_stack_version () {
   local EXITCODE=$?
   if [ $EXITCODE -ne 0 ]; then
       log "ERROR" "[get_prev_cloud_stack_version] error pinging $OLD_ELASTICSEARCH_URL"
-      exit $EXITCODE
+      clean_and_exit $EXITCODE
   fi
   OLD_STACK_VERSION=$(echo $json_result | jq -r '.version.number')
   log "INFO" "[get_prev_cloud_stack_version] Stack version found is $OLD_STACK_VERSION"
+}
+
+# clean_and_exit cleans up temporary files and exits
+clean_and_exit() {
+  log "INFO" "[clean_and_exit] Cleaning up temporary files"
+  if [ -f "$CONFIG_FILE" ]; then
+    log "INFO" "[clean_and_exit] emptying $CONFIG_FILE"
+    echo "{}" > $CONFIG_FILE
+  fi
+  
+  if [ -n "$1" ]; then
+    exit $1
+  else
+    exit 1
+  fi
 }

--- a/src/handler/linux/install.sh
+++ b/src/handler/linux/install.sh
@@ -38,7 +38,7 @@ elif [ -f /etc/debian_version ]; then
     DISTRO_VERSION=$(cat /etc/debian_version)
 elif [ -f /etc/SuSe-release ]; then
     echo -e "Unsupported OS"
-    exit 51
+    clean_and_exit 51
 #elif [ -f /etc/redhat-release ]; then
     # Older Red Hat, CentOS, etc.
 else
@@ -54,11 +54,11 @@ install_dependencies() {
   distro=${DISTRO_NAME,,}
   if [[ "$distro" = "sles" ]] || [[ "$distro" = *"suse"* ]] || [[ "$distro" = *"flatcar"* ]] ; then
     echo -e "Unsupported OS"
-    exit 51
+    clean_and_exit 51
   fi
   if [[ $distro == "redhat"* && $DISTRO_VERSION == "6"* ]] || [[ $distro == "red hat"* && $DISTRO_VERSION == "6"* ]] ; then
     echo -e "Unsupported OS"
-    exit 51
+    clean_and_exit 51
   fi
   log "distro: $DISTRO_NAME version: $DISTRO_VERSION" "INFO"
   if dpkg -S /bin/ls >/dev/null 2>&1; then

--- a/src/handler/linux/newconfig.sh
+++ b/src/handler/linux/newconfig.sh
@@ -14,55 +14,55 @@ sub_name="Elastic Agent"
 
 checkOS
 
-# Unenroll_Old_ElasticAgent_DEB_RPM unenrolls the elastic agent for debian and rpm os's
-Unenroll_Old_ElasticAgent_DEB_RPM()
-{
-  log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Unenrolling elastic agent"
-  get_prev_kibana_host
-  if [[ "$OLD_KIBANA_URL" = "" ]]; then
-    log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Kibana URL could not be found/parsed"
-    return 1
-  fi
-  get_prev_password
-  get_prev_base64Auth
-  if [ "$OLD_PASSWORD" = "" ] && [ "$OLD_BASE64_AUTH" = "" ]; then
-    log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Password could not be found/parsed"
-    return 1
-  fi
-  local cred=""
-  if [[ "$OLD_PASSWORD" != "" ]] && [ "$OLD_PASSWORD" != "null" ]; then
-    get_prev_username
-    if [[ "$OLD_USERNAME" = "" ]]; then
-      log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Username could not be found/parsed"
-      return 1
-    fi
-    cred=${OLD_USERNAME}:${OLD_PASSWORD}
-  else
-    cred=$(echo "$OLD_BASE64_AUTH" | base64 --decode)
-  fi
-  eval $(parse_yaml "/etc/elastic-agent/fleet.yml")
-  if [[ "$agent_id" = "" ]]; then
-    log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Password could not be found/parsed"
-    return 1
-  fi
-  log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Agent ID is $agent_id"
-  if [[ $OLD_STACK_VERSION = "" ]]; then
-    get_prev_cloud_stack_version
-  fi
-  has_fleet_server $OLD_STACK_VERSION
-  data='{"force":"true"}'
-  if [[ $IS_FLEET_SERVER = true ]]; then
-    data='{"revoke":"true"}'
-  fi
-  jsonResult=$(curl -X POST "${OLD_KIBANA_URL}/api/fleet/agents/$agent_id/unenroll"  -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -u "$cred" --data $data )
-  local EXITCODE=$?
-  if [ $EXITCODE -ne 0 ]; then
-    log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] error calling $OLD_KIBANA_URL/api/fleet/agents/$agent_id/unenroll in order to unenroll the agent"
-    return $EXITCODE
-  fi
-  log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Agent has been unenrolled"
-  write_status "$name" "$first_operation" "success" "$message" "$sub_name" "success" "Elastic Agent service has been unenrolled"
-}
+# # Unenroll_Old_ElasticAgent_DEB_RPM unenrolls the elastic agent for debian and rpm os's
+# Unenroll_Old_ElasticAgent_DEB_RPM()
+# {
+#   log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Unenrolling elastic agent"
+#   get_prev_kibana_host
+#   if [[ "$OLD_KIBANA_URL" = "" ]]; then
+#     log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Kibana URL could not be found/parsed"
+#     return 1
+#   fi
+#   get_prev_password
+#   get_prev_base64Auth
+#   if [ "$OLD_PASSWORD" = "" ] && [ "$OLD_BASE64_AUTH" = "" ]; then
+#     log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Password could not be found/parsed"
+#     return 1
+#   fi
+#   local cred=""
+#   if [[ "$OLD_PASSWORD" != "" ]] && [ "$OLD_PASSWORD" != "null" ]; then
+#     get_prev_username
+#     if [[ "$OLD_USERNAME" = "" ]]; then
+#       log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Username could not be found/parsed"
+#       return 1
+#     fi
+#     cred=${OLD_USERNAME}:${OLD_PASSWORD}
+#   else
+#     cred=$(echo "$OLD_BASE64_AUTH" | base64 --decode)
+#   fi
+#   eval $(parse_yaml "/etc/elastic-agent/fleet.yml")
+#   if [[ "$agent_id" = "" ]]; then
+#     log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] Password could not be found/parsed"
+#     return 1
+#   fi
+#   log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Agent ID is $agent_id"
+#   if [[ $OLD_STACK_VERSION = "" ]]; then
+#     get_prev_cloud_stack_version
+#   fi
+#   has_fleet_server $OLD_STACK_VERSION
+#   data='{"force":"true"}'
+#   if [[ $IS_FLEET_SERVER = true ]]; then
+#     data='{"revoke":"true"}'
+#   fi
+#   jsonResult=$(curl -X POST "${OLD_KIBANA_URL}/api/fleet/agents/$agent_id/unenroll"  -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -u "$cred" --data $data )
+#   local EXITCODE=$?
+#   if [ $EXITCODE -ne 0 ]; then
+#     log "ERROR" "[Unenroll_Old_ElasticAgent_DEB_RPM] error calling $OLD_KIBANA_URL/api/fleet/agents/$agent_id/unenroll in order to unenroll the agent"
+#     return $EXITCODE
+#   fi
+#   log "INFO" "[Unenroll_Old_ElasticAgent_DEB_RPM] Agent has been unenrolled"
+#   write_status "$name" "$first_operation" "success" "$message" "$sub_name" "success" "Elastic Agent service has been unenrolled"
+# }
 
 # Uninstall_Old_ElasticAgent_DEB_RPM uninstalls the elastic agent and removes directories for Debian and RPM os's
 Uninstall_Old_ElasticAgent_DEB_RPM() {
@@ -92,9 +92,9 @@ Uninstall_Old_ElasticAgent_DEB_RPM() {
 # Uninstall_Old_ElasticAgent checks distro and removes previous installation of the elastic agent
 Uninstall_Old_ElasticAgent()
 {
-  log "INFO" "[Uninstall_Old_ElasticAgent] Unenrolling Elastic Agent"
-  retry_backoff Unenroll_Old_ElasticAgent_DEB_RPM
-  log "INFO" "[Uninstall_Old_ElasticAgent] Elastic Agent has been unenrolled"
+  # log "INFO" "[Uninstall_Old_ElasticAgent] Unenrolling Elastic Agent"
+  # retry_backoff Unenroll_Old_ElasticAgent_DEB_RPM
+  # log "INFO" "[Uninstall_Old_ElasticAgent] Elastic Agent has been unenrolled"
   if [ "$DISTRO_OS" = "DEB" ] || [ "$DISTRO_OS" = "RPM" ]; then
     retry_backoff Uninstall_Old_ElasticAgent_DEB_RPM
   else
@@ -104,5 +104,3 @@ Uninstall_Old_ElasticAgent()
   log "INFO" "Elastic Agent is uninstalled"
   write_status "$name" "$second_operation" "success" "$message" "$sub_name" "error" "Elastic Agent service has been uninstalled"
 }
-
-

--- a/src/handler/linux/uninstall.sh
+++ b/src/handler/linux/uninstall.sh
@@ -14,55 +14,55 @@ sub_name="Elastic Agent"
 
 checkOS
 
-# Unenroll_ElasticAgent_DEB_RPM unenrolls the elastic agent for Debian and RPM os's
-Unenroll_ElasticAgent_DEB_RPM()
-{
-  log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Unenrolling elastic agent"
-  get_kibana_host
-  if [[ "$KIBANA_URL" = "" ]]; then
-    log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] Kibana URL could not be found/parsed"
-    return 1
-  fi
-  get_password
-  get_base64Auth
-  if [ "$PASSWORD" = "" ] && [ "$BASE64_AUTH" = "" ]; then
-    log "ERROR" "[Enroll_ElasticAgent] Password could not be found/parsed"
-    return 1
-  fi
-  local cred=""
-  if [[ "$PASSWORD" != "" ]] && [ "$PASSWORD" != "null" ]; then
-    get_username
-    if [[ "$USERNAME" = "" ]]; then
-      log "ERROR" "[Enroll_ElasticAgent] Username could not be found/parsed"
-      return 1
-    fi
-    cred=${USERNAME}:${PASSWORD}
-  else
-    cred=$(echo "$BASE64_AUTH" | base64 --decode)
-  fi
-  eval $(parse_yaml "/etc/elastic-agent/fleet.yml")
-  if [[ "$agent_id" = "" ]]; then
-    log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] Password could not be found/parsed"
-    return 1
-  fi
-  log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Agent ID is $agent_id"
-  if [[ $STACK_VERSION = "" ]]; then
-    get_cloud_stack_version
-  fi
-  has_fleet_server $STACK_VERSION
-  data='{"force":"true"}'
-  if [[ $IS_FLEET_SERVER = true ]]; then
-    data='{"revoke":"true"}'
-  fi
-  jsonResult=$(curl -X POST "${KIBANA_URL}/api/fleet/agents/$agent_id/unenroll"  -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -u "$cred" --data $data )
-  local EXITCODE=$?
-  if [ $EXITCODE -ne 0 ]; then
-    log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] error calling $KIBANA_URL/api/fleet/agents/$agent_id/unenroll in order to unenroll the agent"
-    return $EXITCODE
-  fi
-  log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Agent has been unenrolled"
-  write_status "$name" "$first_operation" "success" "$message" "$sub_name" "success" "Elastic Agent service has been unenrolled"
-}
+# # Unenroll_ElasticAgent_DEB_RPM unenrolls the elastic agent for Debian and RPM os's
+# Unenroll_ElasticAgent_DEB_RPM()
+# {
+#   log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Unenrolling elastic agent"
+#   get_kibana_host
+#   if [[ "$KIBANA_URL" = "" ]]; then
+#     log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] Kibana URL could not be found/parsed"
+#     return 1
+#   fi
+#   get_password
+#   get_base64Auth
+#   if [ "$PASSWORD" = "" ] && [ "$BASE64_AUTH" = "" ]; then
+#     log "ERROR" "[Enroll_ElasticAgent] Password could not be found/parsed"
+#     return 1
+#   fi
+#   local cred=""
+#   if [[ "$PASSWORD" != "" ]] && [ "$PASSWORD" != "null" ]; then
+#     get_username
+#     if [[ "$USERNAME" = "" ]]; then
+#       log "ERROR" "[Enroll_ElasticAgent] Username could not be found/parsed"
+#       return 1
+#     fi
+#     cred=${USERNAME}:${PASSWORD}
+#   else
+#     cred=$(echo "$BASE64_AUTH" | base64 --decode)
+#   fi
+#   eval $(parse_yaml "/etc/elastic-agent/fleet.yml")
+#   if [[ "$agent_id" = "" ]]; then
+#     log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] Password could not be found/parsed"
+#     return 1
+#   fi
+#   log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Agent ID is $agent_id"
+#   if [[ $STACK_VERSION = "" ]]; then
+#     get_cloud_stack_version
+#   fi
+#   has_fleet_server $STACK_VERSION
+#   data='{"force":"true"}'
+#   if [[ $IS_FLEET_SERVER = true ]]; then
+#     data='{"revoke":"true"}'
+#   fi
+#   jsonResult=$(curl -X POST "${KIBANA_URL}/api/fleet/agents/$agent_id/unenroll"  -H 'Content-Type: application/json' -H 'kbn-xsrf: true' -u "$cred" --data $data )
+#   local EXITCODE=$?
+#   if [ $EXITCODE -ne 0 ]; then
+#     log "ERROR" "[Unenroll_ElasticAgent_DEB_RPM] error calling $KIBANA_URL/api/fleet/agents/$agent_id/unenroll in order to unenroll the agent"
+#     return $EXITCODE
+#   fi
+#   log "INFO" "[Unenroll_ElasticAgent_DEB_RPM] Agent has been unenrolled"
+#   write_status "$name" "$first_operation" "success" "$message" "$sub_name" "success" "Elastic Agent service has been unenrolled"
+# }
 
 # Uninstall_ElasticAgent_DEB_RPM uninstalls the elastic agent and removes directories for Debian and RPM os's
 Uninstall_ElasticAgent_DEB_RPM() {
@@ -92,9 +92,12 @@ Uninstall_ElasticAgent_DEB_RPM() {
 # Uninstall_ElasticAgent checks distro and removes installation of the elastic agent
 Uninstall_ElasticAgent()
 {
-  log "INFO" "[Uninstall_ElasticAgent] Unenrolling Elastic Agent"
-  retry_backoff Unenroll_ElasticAgent_DEB_RPM
-  log "INFO" "[Uninstall_ElasticAgent] Elastic Agent has been unenrolled"
+  # We are not unenrolling the Agent since we no longer have
+  # the credentials to do so. We are just uninstalling it.
+  #
+  # log "INFO" "[Uninstall_ElasticAgent] Unenrolling Elastic Agent"
+  # retry_backoff Unenroll_ElasticAgent_DEB_RPM
+  # log "INFO" "[Uninstall_ElasticAgent] Elastic Agent has been unenrolled"
   if [ "$DISTRO_OS" = "DEB" ] || [ "$DISTRO_OS" = "RPM" ]; then
     retry_backoff Uninstall_ElasticAgent_DEB_RPM
   else
@@ -106,4 +109,3 @@ Uninstall_ElasticAgent()
 }
 
 Uninstall_ElasticAgent
-

--- a/src/handler/windows/scripts/enable.ps1
+++ b/src/handler/windows/scripts/enable.ps1
@@ -180,7 +180,8 @@ function Install-ElasticAgent {
                 Write-Log $_.ScriptStackTrace "ERROR"
                 # write status for fail
                 Write-Status "$name" "$firstOperation" "error" "$message" "$subName" "error" "Elastic Agent has not been installed"
-                exit 1
+                # exit 1
+                Clean-And-Exit 1
             } else {
                 Write-Log "Elastic Agent installation failed. retrying in 20s" "ERROR"
                 Write-Log $_ "ERROR"
@@ -211,7 +212,8 @@ function Enable-ElasticAgent {
                 Write-Log $_ "ERROR"
                 Write-Log $_.ScriptStackTrace "ERROR"
                 Write-Status "$nameE" "$operationE" "error" "$messageE" "$subName" "error" "Elastic Agent service has not started"
-                exit 1
+                # exit 1
+                Clean-And-Exit 1
             } else {
                 Write-Log "Starting the Elastic Agent has failed. retrying in 20s" "ERROR"
                 Write-Log $_ "ERROR"
@@ -244,7 +246,8 @@ function Reconfigure-ElasticAgent {
                 Write-Log $_ "ERROR"
                 Write-Log $_.ScriptStackTrace "ERROR"
                 Write-Status "$nameE" "$operationE" "error" "$messageE" "$subName" "error" "Elastic Agent service has not been reconfigured"
-                exit 1
+                # exit 1
+                Clean-And-Exit 1
             } else {
                 Write-Log "Starting the Elastic Agent has failed. retrying in 20s" "ERROR"
                 Write-Log $_ "ERROR"
@@ -273,3 +276,4 @@ If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
     Enable-ElasticAgent
 }
 
+Clean-And-Exit 0

--- a/src/handler/windows/scripts/helper.ps1
+++ b/src/handler/windows/scripts/helper.ps1
@@ -880,3 +880,21 @@ function Get-Prev-Stack-Version {
     }
     return ""
 }
+
+# Clean-And-Exit cleans up the config file and exits
+function Clean-And-Exit($exitCode) {
+    $powershellVersion = Get-PowershellVersion
+    Try 
+    {
+        $azureConfigFile = Get-Azure-Latest-Config-File($powershellVersion)
+        Set-Content -Path $azureConfigFile -Value "{}"
+    }
+    Catch
+    {
+        $ErrorMessage = $_.Exception.Message
+        $FailedItem = $_.Exception.ItemName
+        Write-Log "Failed to clear config file: $FailedItem. The error message was $ErrorMessage" "ERROR"
+    }
+
+    exit $exitCode
+}

--- a/src/handler/windows/scripts/newconfig.ps1
+++ b/src/handler/windows/scripts/newconfig.ps1
@@ -9,6 +9,7 @@ $ScriptDirectory = Split-Path $MyInvocation.MyCommand.Path
 $name = "Uninstall elastic agent"
 $firstOperation = "unenrolling elastic agent"
 $secondOperation = "uninstalling elastic agent and removing any elastic agent related folders"
+$operation = "uninstalling elastic agent and removing any elastic agent related folders"
 $message = "Uninstall elastic agent"
 $subName = "Elastic Agent"
 
@@ -20,70 +21,71 @@ function Uninstall-Old-ElasticAgent {
     while (-not $completed) {
         Try
         {
-            $powershellVersion = Get-PowershellVersion
-            $kibanaUrl = Get-Prev-Kibana-URL $powershellVersion
-            if (-Not $kibanaUrl)
-            {
-                throw "Kibana url could not be found"
-            }
-            Write-Log "Found Kibana url $kibanaUrl" "INFO"
-            $password = Get-Prev-Password $powershellVersion
-            $base64Auth = Get-Prev-Base64Auth $powershellVersion
-            if (-Not $password -And -Not $base64Auth)
-            {
-                throw "Password or base64auto key could not be found"
-            }
-            $agentId = Get-Agent-Id "$INSTALL_LOCATION\Elastic\Agent\fleet.yml"
-            if (-Not $agentId)
-            {
-                throw "Agent Id could not be found"
-            }
-            Write-Log "Unenroll elastic agent" "INFO"
-            $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-            $headers.Add("kbn-xsrf", "true")
-            #cred
-            $encodedCredentials = ""
-            if ($password)
-            {
-                $username = Get-Prev-Username $powershellVersion
-                if (-Not $username)
-                {
-                    throw "Username could not be found"
-                }
-                $pair = "$( $username ):$( $password )"
-                $encodedCredentials = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-            }
-            else
-            {
-                $encodedCredentials = $base64Auth
-            }
-            $headers.Add('Authorization', "Basic $encodedCredentials")
-            $body = (@{ 'force' = $true } | ConvertTo-Json)
-            $OLD_STACK_VERSION = Get-Prev-Stack-Version
-            if (HasFleetServer("$OLD_STACK_VERSION")) {
-                $body=(@{'revoke' = $true} | ConvertTo-Json)
-            }
-            $jsonResult = ''
-            if ( $powershellVersion -gt 3 ) {
-                $headers.Add("Accept","application/json")
-            }
-            try {
-                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                $jsonResult = Invoke-WebRequest -Uri "$( $kibanaUrl )/api/fleet/agents/$( $agentId )/unenroll" -Body $body  -Method 'POST' -Headers $headers -UseBasicParsing -ContentType 'application/json; charset=utf-8'
-            } catch {
-                $jsonResult = ConvertFrom-Json $result.ErrorDetails.Message  | Select-Object
-            }
-            if ($jsonResult.statuscode -eq '200')
-            {
-                Write-Log "Unenrollment succeeded" "INFO"
-            }
-            elseif ($jsonResult.statuscode -eq '404' -And $jsonResult.error -eq "Not Found") {
-                Write-Log "Elastic agent was previously unenrolled" "INFO"
-            }
-            else {
-                throw "Unenrolling the agent failed, api request returned status $jsonResult.statuscode"
-            }
-            Write-Status "$name" "$firstOperation" "transitioning" "$message" "$subName" "success" "Elastic Agent service has been unenrolled"
+            # $powershellVersion = Get-PowershellVersion
+            # $kibanaUrl = Get-Prev-Kibana-URL $powershellVersion
+            # if (-Not $kibanaUrl)
+            # {
+            #     throw "Kibana url could not be found"
+            # }
+            # Write-Log "Found Kibana url $kibanaUrl" "INFO"
+            # $password = Get-Prev-Password $powershellVersion
+            # $base64Auth = Get-Prev-Base64Auth $powershellVersion
+            # if (-Not $password -And -Not $base64Auth)
+            # {
+            #     throw "Password or base64auto key could not be found"
+            # }
+            # $agentId = Get-Agent-Id "$INSTALL_LOCATION\Elastic\Agent\fleet.yml"
+            # if (-Not $agentId)
+            # {
+            #     throw "Agent Id could not be found"
+            # }
+            # Write-Log "Unenroll elastic agent" "INFO"
+            # $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+            # $headers.Add("kbn-xsrf", "true")
+            # #cred
+            # $encodedCredentials = ""
+            # if ($password)
+            # {
+            #     $username = Get-Prev-Username $powershellVersion
+            #     if (-Not $username)
+            #     {
+            #         throw "Username could not be found"
+            #     }
+            #     $pair = "$( $username ):$( $password )"
+            #     $encodedCredentials = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+            # }
+            # else
+            # {
+            #     $encodedCredentials = $base64Auth
+            # }
+            # $headers.Add('Authorization', "Basic $encodedCredentials")
+            # $body = (@{ 'force' = $true } | ConvertTo-Json)
+            # $OLD_STACK_VERSION = Get-Prev-Stack-Version
+            # if (HasFleetServer("$OLD_STACK_VERSION")) {
+            #     $body=(@{'revoke' = $true} | ConvertTo-Json)
+            # }
+            # $jsonResult = ''
+            # if ( $powershellVersion -gt 3 ) {
+            #     $headers.Add("Accept","application/json")
+            # }
+            # try {
+            #     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            #     $jsonResult = Invoke-WebRequest -Uri "$( $kibanaUrl )/api/fleet/agents/$( $agentId )/unenroll" -Body $body  -Method 'POST' -Headers $headers -UseBasicParsing -ContentType 'application/json; charset=utf-8'
+            # } catch {
+            #     $jsonResult = ConvertFrom-Json $result.ErrorDetails.Message  | Select-Object
+            # }
+            # if ($jsonResult.statuscode -eq '200')
+            # {
+            #     Write-Log "Unenrollment succeeded" "INFO"
+            # }
+            # elseif ($jsonResult.statuscode -eq '404' -And $jsonResult.error -eq "Not Found") {
+            #     Write-Log "Elastic agent was previously unenrolled" "INFO"
+            # }
+            # else {
+            #     throw "Unenrolling the agent failed, api request returned status $jsonResult.statuscode"
+            # }
+            # Write-Status "$name" "$firstOperation" "transitioning" "$message" "$subName" "success" "Elastic Agent service has been unenrolled"
+
             Write-Log "Uninstalling Elastic Agent" "INFO"
             & "$INSTALL_LOCATION\Elastic\Agent\elastic-agent.exe" uninstall --force
             Write-Log "Elastic Agent has been uninstalled" "INFO"
@@ -91,7 +93,7 @@ function Uninstall-Old-ElasticAgent {
             Remove-Item "$INSTALL_LOCATION\Elastic\Agent" -Recurse -Force
             Remove-Item "$INSTALL_LOCATION\Elastic-Agent" -Recurse -Force
             Write-Log "elastic agent directories removed" "INFO"
-            Write-Status "$name" "$secondOperation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
+            Write-Status "$name" "$operation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
             $completed = $true
         }
         Catch {
@@ -99,8 +101,9 @@ function Uninstall-Old-ElasticAgent {
                 Write-Log "Elastic Agent installation failed after 3 retries" "ERROR"
                 Write-Log $_ "ERROR"
                 Write-Log $_.ScriptStackTrace "ERROR"
-                Write-Status "$name" "$firstOperation" "error" "$message" "$subName" "error" "Elastic Agent service has been uninstalled"
-                exit 1
+                Write-Status "$name" "$operation" "error" "$message" "$subName" "error" "Elastic Agent service has been uninstalled"
+                # exit 1
+                Clean-And-Exit 1
             } else {
                 Write-Log "Elastic Agent installation failed. retrying in 20s" "ERROR"
                 Write-Log $_ "ERROR"

--- a/src/handler/windows/scripts/uninstall.ps1
+++ b/src/handler/windows/scripts/uninstall.ps1
@@ -9,6 +9,8 @@ $ScriptDirectory = Split-Path $MyInvocation.MyCommand.Path
 $name = "Uninstall elastic agent"
 $firstOperation = "unenrolling elastic agent"
 $secondOperation = "uninstalling elastic agent and removing any elastic agent related folders"
+$operation = "uninstalling elastic agent and removing any elastic agent related folders"
+
 $message = "Uninstall elastic agent"
 $subName = "Elastic Agent"
 
@@ -22,61 +24,61 @@ function Uninstall-ElasticAgent {
     $completed = $false
     while (-not $completed) {
         Try {
-            $powershellVersion = Get-PowershellVersion
-            $kibanaUrl = Get-Kibana-URL $powershellVersion
-            if (-Not $kibanaUrl) {
-                throw "Kibana url could not be found"
-            }
-            $password = Get-Password $powershellVersion
-            $base64Auth = Get-Base64Auth $powershellVersion
-            if (-Not $password -And -Not $base64Auth) {
-                throw "Password  or base64auto key could not be found"
-            }
-            $agentId=Get-Agent-Id "$INSTALL_LOCATION\Elastic\Agent\fleet.yml"
-            if (-Not $agentId) {
-                throw "Agent Id could not be found"
-            }
-            Write-Log "Unenroll elastic agent" "INFO"
-            $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-            $headers.Add("kbn-xsrf", "true")
-            #cred
-            $encodedCredentials = ""
-            if ($password) {
-                $username = Get-Username $powershellVersion
-                if (-Not $username) {
-                    throw "Username could not be found"
-                }
-                $pair = "$($username):$($password)"
-                $encodedCredentials = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-            } else {
-                $encodedCredentials = $base64Auth
-            }
-            $headers.Add('Authorization', "Basic $encodedCredentials")
-            $body=(@{'force' = $true} | ConvertTo-Json)
-            $STACK_VERSION= Get-Stack-Version
-            if (HasFleetServer("$STACK_VERSION")) {
-                $body=(@{'revoke' = $true} | ConvertTo-Json)
-            }
-            if ( $powershellVersion -gt 3 ) {
-                $headers.Add("Accept","application/json")
-            }
-            try {
-                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                $jsonResult = Invoke-WebRequest -Uri "$($kibanaUrl)/api/fleet/agents/$($agentId)/unenroll" -Body $body  -Method 'POST' -Headers $headers -UseBasicParsing -ContentType 'application/json; charset=utf-8'
-            } catch {
-                $jsonResult = ConvertFrom-Json $result.ErrorDetails.Message  | Select-Object
-            }
-            if ($jsonResult.statuscode -eq '200')
-            {
-                Write-Log "Unenrollment succeeded" "INFO"
-            }
-            elseif ($jsonResult.statuscode -eq '404' -And $jsonResult.error -eq "Not Found" ) {
-                Write-Log "Elastic agent was previously unenrolled" "INFO"
-            }
-            else {
-                throw "Unenrolling the agent failed, api request returned status $jsonResult.statuscode"
-            }
-            Write-Status "$name" "$firstOperation" "transitioning" "$message" "$subName" "success" "Elastic Agent service has been unenrolled"
+            # $powershellVersion = Get-PowershellVersion
+            # $kibanaUrl = Get-Kibana-URL $powershellVersion
+            # if (-Not $kibanaUrl) {
+            #     throw "Kibana url could not be found"
+            # }
+            # $password = Get-Password $powershellVersion
+            # $base64Auth = Get-Base64Auth $powershellVersion
+            # if (-Not $password -And -Not $base64Auth) {
+            #     throw "Password  or base64auto key could not be found"
+            # }
+            # $agentId=Get-Agent-Id "$INSTALL_LOCATION\Elastic\Agent\fleet.yml"
+            # if (-Not $agentId) {
+            #     throw "Agent Id could not be found"
+            # }
+            # Write-Log "Unenroll elastic agent" "INFO"
+            # $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+            # $headers.Add("kbn-xsrf", "true")
+            # #cred
+            # $encodedCredentials = ""
+            # if ($password) {
+            #     $username = Get-Username $powershellVersion
+            #     if (-Not $username) {
+            #         throw "Username could not be found"
+            #     }
+            #     $pair = "$($username):$($password)"
+            #     $encodedCredentials = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+            # } else {
+            #     $encodedCredentials = $base64Auth
+            # }
+            # $headers.Add('Authorization', "Basic $encodedCredentials")
+            # $body=(@{'force' = $true} | ConvertTo-Json)
+            # $STACK_VERSION= Get-Stack-Version
+            # if (HasFleetServer("$STACK_VERSION")) {
+            #     $body=(@{'revoke' = $true} | ConvertTo-Json)
+            # }
+            # if ( $powershellVersion -gt 3 ) {
+            #     $headers.Add("Accept","application/json")
+            # }
+            # try {
+            #     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            #     $jsonResult = Invoke-WebRequest -Uri "$($kibanaUrl)/api/fleet/agents/$($agentId)/unenroll" -Body $body  -Method 'POST' -Headers $headers -UseBasicParsing -ContentType 'application/json; charset=utf-8'
+            # } catch {
+            #     $jsonResult = ConvertFrom-Json $result.ErrorDetails.Message  | Select-Object
+            # }
+            # if ($jsonResult.statuscode -eq '200')
+            # {
+            #     Write-Log "Unenrollment succeeded" "INFO"
+            # }
+            # elseif ($jsonResult.statuscode -eq '404' -And $jsonResult.error -eq "Not Found" ) {
+            #     Write-Log "Elastic agent was previously unenrolled" "INFO"
+            # }
+            # else {
+            #     throw "Unenrolling the agent failed, api request returned status $jsonResult.statuscode"
+            # }
+            # Write-Status "$name" "$firstOperation" "transitioning" "$message" "$subName" "success" "Elastic Agent service has been unenrolled"
             Write-Log "Uninstalling Elastic Agent" "INFO"
             & "$INSTALL_LOCATION\Elastic\Agent\elastic-agent.exe" uninstall --force
             Write-Log "Elastic Agent has been uninstalled" "INFO"
@@ -84,7 +86,7 @@ function Uninstall-ElasticAgent {
             Remove-Item "$INSTALL_LOCATION\Elastic\Agent" -Recurse -Force
             Remove-Item "$INSTALL_LOCATION\Elastic-Agent" -Recurse -Force
             Write-Log "elastic agent directories removed" "INFO"
-            Write-Status "$name" "$secondOperation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
+            Write-Status "$name" "$operation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
             $completed = $true
         }
         Catch {
@@ -92,8 +94,9 @@ function Uninstall-ElasticAgent {
                 Write-Log "Elastic Agent installation failed after 3 retries" "ERROR"
                 Write-Log $_ "ERROR"
                 Write-Log $_.ScriptStackTrace "ERROR"
-                Write-Status "$name" "$firstOperation" "error" "$message" "$subName" "error" "Elastic Agent service has been uninstalled"
-                exit 1
+                Write-Status "$name" "$operation" "error" "$message" "$subName" "error" "Elastic Agent service has been uninstalled"
+                # exit 1
+                Clean-And-Exit 1
             } else {
                 Write-Log "Elastic Agent installation failed. retrying in 20s" "ERROR"
                 Write-Log $_ "ERROR"
@@ -110,6 +113,6 @@ If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
     Uninstall-ElasticAgent
 } Else {
     Write-Log "Elastic Agent has been previously uninstalled. Cannot be found as a service." "INFO"
-    Write-Status "$name" "$secondOperation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
+    Write-Status "$name" "$operation" "success" "$message" "$subName" "success" "Elastic Agent service has been uninstalled"
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Settings should not stay on the VM after the installation, even if encrypted.

Consequently, the uninstall operation will no longer unenroll the Agent from the cluster.

### Change description
<!-- What does your code do? -->

- Add a "clean and exit" function to both Linux and Windows version to empty the settings file after the installation completes
- Remove unenrollment from the uninstall operation

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are appropriately filled.
* [ ] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.