### PR TITLE
Create catalog-info file and onboarding buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Example test"
+    command: echo "Hello!"

--- a/.buildkite/pull-request.json
+++ b/.buildkite/pull-request.json
@@ -1,0 +1,18 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipelineSlug": "azure-vm-extension",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "set_commit_status": true,
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+      "skip_ci_labels": ["skip-ci"],
+      "skip_target_branches": [ ],
+      "skip_ci_on_only_changed": ["\\.md$"]
+    }
+  ]
+}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,18 @@
+# Declare a Backstage Component that represents your application.
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: azure-vm-extension
+
+spec:
+  type: application # or service, library, etc.
+  owner: group:obs-cloud-monitoring # Find your group in https://backstage.elastic.dev/catalog?filters%5Bkind%5D=group
+  lifecycle: production # or production, deprecated, etc.
+
+# Declare your Buildkite pipeline.
+# This declaration creates the Backstage entity and the pipeline in Buildkite.
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,43 +1,28 @@
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-azure-vm-extension
-  description: 'Pipeline for Azure VM extension project'
+  description: Buildkite Pipeline for azure-vm-extension
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/azure-vm-extension
 
 spec:
   type: buildkite-pipeline
-  owner: group:azure-vm-extension-management
+  owner: group:obs-cloud-monitoring
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
       name: azure-vm-extension
-      description: 'Pipeline for Azure VM extension project'
     spec:
-      branch_configuration: "main"
-      pipeline_file: ".buildkite/pipeline.yml"
-      provider_settings:
-        build_pull_request_forks: false
-        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
-        build_tags: false
-        filter_enabled: true
-        filter_condition: >-
-          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       repository: elastic/azure-vm-extension
-      cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main'
-      skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main'
-      env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        azure-vm-extension-management:
+        obs-cloud-monitoring:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-azure-vm-extension
+  description: 'Pipeline for Azure VM extension project'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/azure-vm-extension
+
+spec:
+  type: buildkite-pipeline
+  owner: group:azure-vm-extension-management
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: azure-vm-extension
+      description: 'Pipeline for Azure VM extension project'
+    spec:
+      branch_configuration: "main"
+      pipeline_file: ".buildkite/pipeline.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: false
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/azure-vm-extension
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      teams:
+        azure-vm-extension-management:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
This PR is to create `./catalog-info.yaml` file and start buildkite. The `catalog-info.yaml` file is where you can define your infrastructure needs (such as Buildkite pipelines) in the form of [Real Resource Entities](https://github.com/elastic/real-resource-entities).