### PR TITLE
Add support in install script for ubuntu:24.04

### DIFF
--- a/CHANGELOG-release.asciidoc
+++ b/CHANGELOG-release.asciidoc
@@ -1,3 +1,8 @@
+[[release-notes-1.3.1.0]]
+=== Elastic Agent VM extension version 1.3.1.0
+
+- Add suppor for Ubuntu 24.04
+
 [[release-notes-1.3.0.0]]
 === Elastic Agent VM extension version 1.3.0.0
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To automate the installation and configuration of the Elastic Agent, the Azure V
 
 | VM extension version | Elastic Cloud dependency      |
 |----------|--------------|
+| 1.3.1.0 | 7.13.0 or later |
 | 1.3.0.0 | 7.13.0 or later |
 | 1.2.0.0 | 7.13.0 or later |
 | 1.1.1.0 | 7.13.0 or later |

--- a/src/handler/linux/helper.sh
+++ b/src/handler/linux/helper.sh
@@ -33,7 +33,7 @@ POLICY_NAME="Azure VM extension policy"
 # checkOS checks distro
 checkOS()
 {
-  if dpkg -S /bin/ls >/dev/null 2>&1 || dpkg -S /usr/bin/ls >/dev/null 2>&1; then
+  if dpkg -S /bin/ls >/dev/null 2>&1 || dpkg -S /usr/bin/ls >/dev/null 2>&1
   then
     DISTRO_OS="DEB"
     echo "[checkOS] distro is $DISTRO_OS" "INFO"

--- a/src/handler/linux/helper.sh
+++ b/src/handler/linux/helper.sh
@@ -33,7 +33,7 @@ POLICY_NAME="Azure VM extension policy"
 # checkOS checks distro
 checkOS()
 {
-  if dpkg -S /bin/ls >/dev/null 2>&1
+  if dpkg -S /bin/ls >/dev/null 2>&1 || dpkg -S /usr/bin/ls >/dev/null 2>&1; then
   then
     DISTRO_OS="DEB"
     echo "[checkOS] distro is $DISTRO_OS" "INFO"

--- a/src/handler/linux/install.sh
+++ b/src/handler/linux/install.sh
@@ -61,7 +61,7 @@ install_dependencies() {
     clean_and_exit 51
   fi
   log "distro: $DISTRO_NAME version: $DISTRO_VERSION" "INFO"
-  if dpkg -S /bin/ls >/dev/null 2>&1; then
+  if dpkg -S /bin/ls >/dev/null 2>&1 || dpkg -S /usr/bin/ls >/dev/null 2>&1; then
     log "[install_dependencies] distro is Debian" "INFO"
     sudo apt-get update
     if [ $(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed") -eq 0 ]; then

--- a/src/test_ubuntu.ps2
+++ b/src/test_ubuntu.ps2
@@ -1,0 +1,2 @@
+ docker build -f ubuntu-24-04.dockerfile --tag vm_extension_ubuntu .
+ docker run  --name vm_extension_ubuntu_run --rm -i -t vm_extension_ubuntu bash -c "./handler/scripts/linux/install.sh;bash" --privileged=true

--- a/src/ubuntu-24-04.dockerfile
+++ b/src/ubuntu-24-04.dockerfile
@@ -1,0 +1,8 @@
+FROM jrei/systemd-ubuntu:24.04 AS vm_extension_ubuntu
+
+RUN apt-get update && apt-get -y install sudo wget
+WORKDIR /sln
+
+COPY ./handler ./handler
+COPY settings ./tests
+


### PR DESCRIPTION
In `ubuntu:24.04` the `coreutils` package installs `ls` only in `/usr/bin/ls` path and not in `/bin/ls` as it was the case until `ubuntu:22.04`.

This makes the install.sh script to fail in https://github.com/elastic/azure-vm-extension/blob/c5d128b91938cbba555a4ebf9e04bc998caca941/src/handler/linux/install.sh#L64

An `OR` statement is added to cover this case too.